### PR TITLE
chore: add required labels check

### DIFF
--- a/.github/workflows/required-labels.yaml
+++ b/.github/workflows/required-labels.yaml
@@ -1,0 +1,11 @@
+name: Required Labels
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, synchronize, reopened]
+
+jobs:
+  labels-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hudl/platform-actions/required-labels-check@latest


### PR DESCRIPTION
## Summary

- Adds the required labels workflow using `hudl/platform-actions/required-labels-check@latest`

Part of the org-wide rollout of required PR labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)